### PR TITLE
[Resolves #956] Update Alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.11
 
 RUN apk add --update --no-cache \
     patch \


### PR DESCRIPTION
The current Sceptre build[1] is failing with the following meessage:

```
Failed to build cryptography
ERROR: Could not build wheels for cryptography which use PEP 517 and cannot be installed directly
```

The problem is due to building against older libraries in Alpine ver 3.7.
That error does not happen when building with Alpine ver 3.11

Also Alpine 3.7 is no longer supported[2] therefore  we update to ver 3.11

[1] https://app.circleci.com/pipelines/github/Sceptre/sceptre/285/workflows/3b87741b-62e6-4acf-8159-210164c769e3/jobs/5061
[2] https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases