### PR TITLE
[Resolves #956] attempt to fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,7 @@ RUN apk add --update --no-cache \
     rust \
     cargo
 
-RUN pip3 install --no-cache-dir --upgrade pip \
- && pip3 install --no-cache-dir virtualenv \
+RUN pip3 install --no-cache-dir virtualenv \
  && pip3 install --no-cache-dir tox \
  && addgroup -g 3434 circleci \
  && adduser -D -u 3434 -G circleci -s /bin/bash circleci


### PR DESCRIPTION
Attempt to fix build failure `error: can't find Rust compiler`.

The docs says try to update pip or install rust..
https://cryptography.io/en/latest/faq.html#installing-cryptography-fails-with-error-can-not-find-rust-compiler`

What worked:
* update to alpine version 3.13
* install rust

Upgrading pip did not fix the problem and it wasn't required after updating alpine and installing rust.