### PR TITLE
Add explicit Python versions including 3.8 and 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,9 @@ RUN apk add --update --no-cache \
     cargo
 
 RUN pip3 install --no-cache-dir virtualenv \
- && pip3 install --no-cache-dir tox \
- && addgroup -g 3434 circleci \
- && adduser -D -u 3434 -G circleci -s /bin/bash circleci
+    && pip3 install --no-cache-dir tox \
+    && addgroup -g 3434 circleci \
+    && adduser -D -u 3434 -G circleci -s /bin/bash circleci
 
 USER circleci
 
@@ -41,7 +41,10 @@ ENV LANG=C.UTF-8 \
 
 RUN git clone --depth 1 https://github.com/pyenv/pyenv.git $PYENV_HOME \
     && rm -rfv $PYENV_HOME/.git \
-    && pyenv install 3.6-dev \
-    && pyenv install 3.7-dev
+    && pyenv install 3.6.13 \
+    && pyenv install 3.7.10 \
+    && pyenv install 3.8.9 \
+    && pyenv install 3.9.4 \
+    && pyenv global system 3.6.13 3.7.10 3.8.9 3.9.4
 
 CMD ["/bin/sh"]


### PR DESCRIPTION
Now instead of installing just the "dev" versions of 3.6 and 3.7, we explicitly install the latest versions of 3.6, 3.7, 3.8, and 3.9.

I also added a `pyenv global` to "activate" all of these Python versions, so that the repositories no longer need to rely on a `.python-version` file to find the appropriate versions.

Built and tested locally:

```sh
> docker run -it sceptre
~ $ python3.6
Python 3.6.13 (default, Apr 21 2021, 18:35:04)
[GCC 10.2.1 20201203] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
~ $ python3.7
Python 3.7.10 (default, Apr 21 2021, 18:36:29)
[GCC 10.2.1 20201203] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
~ $ python3.8
Python 3.8.8 (default, Mar 15 2021, 13:10:14)
[GCC 10.2.1 20201203] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
~ $ python3.9
Python 3.9.4 (default, Apr 21 2021, 18:40:51)
[GCC 10.2.1 20201203] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
~ $
```