### PR TITLE
Install poetry into the base image for use in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ARG PYENV_HOME=/home/circleci/.pyenv
 
 ENV LANG=C.UTF-8 \
     HOME=/home/circleci \
-    PATH=$PYENV_HOME/shims:$PYENV_HOME/bin:$PATH
+    PATH=$PYENV_HOME/shims:$PYENV_HOME/bin:/home/circleci/.poetry/bin:$PATH
 
 RUN git clone --depth 1 https://github.com/pyenv/pyenv.git $PYENV_HOME \
     && rm -rfv $PYENV_HOME/.git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,7 @@ RUN git clone --depth 1 https://github.com/pyenv/pyenv.git $PYENV_HOME \
     && pyenv install 3.9.4 \
     && pyenv global system 3.6.13 3.7.10 3.8.9 3.9.4
 
+# Install the latest Poetry
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+
 CMD ["/bin/sh"]


### PR DESCRIPTION
This will have zero impact on existing CI jobs, and will allow progress to move forward on https://github.com/Sceptre/sceptre/pull/1035 without having to continue ugly attempts at path munging to get poetry working properly.

This is the exact approach taken by the base CircleCI Python images:
https://github.com/CircleCI-Public/cimg-python/blob/master/Dockerfile.template#L43