### PR TITLE
Remove python 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,11 +41,10 @@ ENV LANG=C.UTF-8 \
 
 RUN git clone --depth 1 https://github.com/pyenv/pyenv.git $PYENV_HOME \
     && rm -rfv $PYENV_HOME/.git \
-    && pyenv install 3.6.13 \
     && pyenv install 3.7.10 \
     && pyenv install 3.8.9 \
     && pyenv install 3.9.4 \
-    && pyenv global system 3.6.13 3.7.10 3.8.9 3.9.4
+    && pyenv global system 3.7.10 3.8.9 3.9.4
 
 # Install the latest Poetry
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -


### PR DESCRIPTION
Sceptre does not support python 3.6 so dropping
this version from the docker image.  Support for 3.6
was dropped in PR https://github.com/Sceptre/sceptre/pull/1206