### PR TITLE
update circleci base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
     environment:
       IMAGE_NAME: cloudreach/sceptre-circleci
     docker:
-      - image: cimg/base:2021.03
+      - image: cimg/base:2022.05
 
 jobs:
   build-docker-image:


### PR DESCRIPTION
Circleci failed to do checkout action after updating to use alpine 3.16
Attempt to fix this by updating the base circleci docker image.