### PR TITLE
Fix make

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,8 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.14
       - run:
           name: Load Docker image archive
           command: docker load -i /tmp/workspace/image.tar
@@ -46,7 +47,8 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.14
       - run:
           name: Load archived Docker image
           command: docker load -i /tmp/workspace/image.tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ jobs:
   build-docker-image:
     executor: docker-publisher
     steps:
+      - setup_remote_docker:
+          version: 20.10.14
       - checkout
       - setup_remote_docker
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,9 @@ jobs:
   build-docker-image:
     executor: docker-publisher
     steps:
+      - checkout
       - setup_remote_docker:
           version: 20.10.14
-      - checkout
-      - setup_remote_docker
       - run:
           name: Build Docker Image
           command: |


### PR DESCRIPTION
Building with alpine 3.16 fails with
`make: /bin/sh: Operation not permitted`.

Attempt to fix by following instructions from circleci discussion[1]

[1] https://discuss.circleci.com/t/unable-to-use-make/40552