### PR TITLE
Install pyenv-virtualenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,12 +40,14 @@ ENV LANG=C.UTF-8 \
     PATH=$PYENV_HOME/shims:$PYENV_HOME/bin:/home/circleci/.poetry/bin:$PATH
 
 RUN git clone --depth 1 https://github.com/pyenv/pyenv.git $PYENV_HOME \
+    && git clone https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv \
     && rm -rfv $PYENV_HOME/.git \
     && pyenv install 3.7.10 \
     && pyenv install 3.8.9 \
     && pyenv install 3.9.4 \
     && pyenv install 3.10.4 \
     && pyenv global system 3.7.10 3.8.9 3.9.4 3.10.4
+
 
 # Install the latest Poetry
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -


### PR DESCRIPTION
Setup pyenv-virtualenv to allow downstream builds to
use pyenv to easily create and run tests in virtual
environments.