### PR TITLE
[Resolves #17] Fix docker image build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,145 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+venv/
+.venv/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+.python-version
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+test-results.xml
+test-reports/
+test-results/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Sceptre directories users may have for testing
+/config
+/templates
+
+### OSX ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### PyCharm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/
+
+## File-based project format:
+*.iws
+
+# Jekyll settings
+
+.bundle/
+docs/vendor/*
+_site/
+.sass-cache/
+.jekyll-metadata
+
+# Sphinx docs
+/docs/docs/api
+/docs/_api/_build/
+/docs/_api/modules.rst
+/docs/_api/sceptre.rst
+/docs/_api/sceptre.hooks.rst
+/docs/_api/sceptre.resolvers.rst
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+# temp files
+temp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,55 +1,9 @@
-FROM alpine:3.16
+FROM cimg/python:3.11.1-node
 
-RUN apk add --update --no-cache \
-    patch \
-    git \
-    openssh \
-    ca-certificates \
-    build-base \
-    curl \
-    bzip2-dev \
-    bash \
-    py3-pip \
-    python3 \
-    python3-dev \
-    libffi-dev \
-    ruby \
-    ruby-dev \
-    ruby-bundler \
-    ruby-json \
-    readline-dev \
-    openssl-dev \
-    sqlite-dev \
-    zlib-dev \
-    rust \
-    cargo
-
-RUN pip3 install --no-cache-dir virtualenv \
-    && pip3 install --no-cache-dir tox \
-    && addgroup -g 3434 circleci \
-    && adduser -D -u 3434 -G circleci -s /bin/bash circleci
-
-USER circleci
-
-WORKDIR /home/circleci
-
-ARG PYENV_HOME=/home/circleci/.pyenv
-
-ENV LANG=C.UTF-8 \
-    HOME=/home/circleci \
-    PATH=$PYENV_HOME/shims:$PYENV_HOME/bin:/home/circleci/.poetry/bin:$PATH
-
-RUN git clone --depth 1 https://github.com/pyenv/pyenv.git $PYENV_HOME \
-    && git clone https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv \
-    && rm -rfv $PYENV_HOME/.git \
-    && pyenv install 3.7.10 \
+RUN pyenv install 3.7.10 \
     && pyenv install 3.8.9 \
     && pyenv install 3.9.4 \
     && pyenv install 3.10.4 \
     && pyenv global system 3.7.10 3.8.9 3.9.4 3.10.4
-
-
-# Install the latest Poetry
-RUN curl -sSL https://install.python-poetry.org | python -
 
 CMD ["/bin/sh"]


### PR DESCRIPTION
Base the sceptre docker image on the official python circleci docker image[1]
which supports pyenv, pipenv, poetry and node

[1] https://hub.docker.com/r/cimg/python